### PR TITLE
Resizing Maintenance

### DIFF
--- a/common/CommonAPI.h
+++ b/common/CommonAPI.h
@@ -806,6 +806,9 @@ public:
 		FeatureType* features = nullptr;
 	};
 
+	struct InitArgs {
+	};
+
 	struct InitOutput
 	{
 		enum E_QUEUE_TYPE


### PR DESCRIPTION
Maintenance for resizing, TODOS:

Bigger maintenance crap:
- [ ]  redo surfaceFormat into a list (in order of preference) of "acceptable" formats (format, colorspace, OETF) https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L944
- [ ]  fix this https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L207
Small maintenance crap:
- [ ]  the sc argument is unused https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1712
- [ ]  add a comment here https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1553 that its just until OpenGL backend reports swapchain formats properly 
- [ ]  whatever is not templated, should move to a CommonAPI.cpp file (before everything was templated)
- [ ]  Change the signature of this function https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L933 to be static InitOutput Init(InitParams&& params);
- [ ]  turn all existing arguments into InitParams struct members with nice default values (makes any further refactors easier across 50 examples)
    - [ ]  some members from InitOutput would need to be added to InitParams like window, windowCb and windowManager (android does stuff weird)
    - [ ]  add a new, last smart_refctd_ptr<system::ILogger> m_logger=nullptr member and solve this comment https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L956-958
- [ ]  use your format promotion to promote depth format in CommonAPI https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1581 and https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1641
- [ ]  type returned should be a core::smart_refctd_dynamic_array of swapchain image count instead of fixed size std::array in https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1638
- [ ]  remove the default arg here https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1762
- [ ]  use core::bitflag here https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/blob/example-fixes/common/CommonAPI.h#L1787
- [ ]  log failures nicely (example will currently blow up if any thing that can return nullptr or error does so)