### PR TITLE
Update PathTracer's UV to be packed as 32 bit float attribute components 

### DIFF
--- a/22.RaytracedAO/Renderer.cpp
+++ b/22.RaytracedAO/Renderer.cpp
@@ -318,7 +318,7 @@ Renderer::InitializationData Renderer::initSceneObjects(const SAssetBundle& mesh
 
 				IMeshPackerV2Base::SupportedFormatsContainer formats;
 				formats.insert(EF_R32G32B32_SFLOAT);
-				formats.insert(EF_R32G32_UINT);
+				formats.insert(EF_R32G32B32_UINT);
 				auto cpump = core::make_smart_refctd_ptr<CCPUMeshPackerV2<>>(allocParams,formats,minTrisBatch,maxTrisBatch);
 				uint32_t mdiBoundMax=0u,batchInstanceBoundTotal=0u;
 				core::vector<CPUMeshPacker::ReservedAllocationMeshBuffers> allocData;

--- a/22.RaytracedAO/Renderer.cpp
+++ b/22.RaytracedAO/Renderer.cpp
@@ -359,7 +359,8 @@ Renderer::InitializationData Renderer::initSceneObjects(const SAssetBundle& mesh
 							
 							struct CombinedNormalUV
 							{
-								uint32_t normal, u, v;
+								uint32_t normal;
+								float u, v;
 							};
 							static_assert(sizeof(CombinedNormalUV) == sizeof(float) * 3u);
 

--- a/22.RaytracedAO/Renderer.cpp
+++ b/22.RaytracedAO/Renderer.cpp
@@ -347,20 +347,22 @@ Renderer::InitializationData Renderer::initSceneObjects(const SAssetBundle& mesh
 							assert(meshBuffer->getInstanceCount()==instanceCount);
 							// We'll disable certain attributes to ensure we only copy position, normal and uv attribute
 							SVertexInputParams& vertexInput = meshBuffer->getPipeline()->getVertexInputParams();
-							// but we'll pack normals and UVs together to save one SSBO binding (and quantize UVs to half floats)
+							// but we'll pack normals and UVs together to save one SSBO binding, but no quantization of UVs to keep accurate floating point precision for baricentrics
 							constexpr auto freeBinding = 15u;
 							vertexInput.attributes[combinedNormalUVAttributeIx].binding = freeBinding;
-							vertexInput.attributes[combinedNormalUVAttributeIx].format = EF_R32G32_UINT;
+							vertexInput.attributes[combinedNormalUVAttributeIx].format = EF_R32G32B32_UINT;
 							vertexInput.attributes[combinedNormalUVAttributeIx].relativeOffset = 0u;
 							vertexInput.enabledBindingFlags |= 0x1u<<freeBinding;
 							vertexInput.bindings[freeBinding].inputRate = EVIR_PER_VERTEX;
 							vertexInput.bindings[freeBinding].stride = 0u;
 							const auto approxVxCount = IMeshManipulator::upperBoundVertexID(meshBuffer)+meshBuffer->getBaseVertex();
+							
 							struct CombinedNormalUV
 							{
-								uint32_t nml;
-								uint16_t u,v;
+								uint32_t normal, u, v;
 							};
+							static_assert(sizeof(CombinedNormalUV) == sizeof(float) * 3u);
+
 							auto newBuff = core::make_smart_refctd_ptr<ICPUBuffer>(sizeof(CombinedNormalUV)*approxVxCount);
 							auto* dst = reinterpret_cast<CombinedNormalUV*>(newBuff->getPointer())+meshBuffer->getBaseVertex();
 							meshBuffer->setVertexBufferBinding({0u,newBuff},freeBinding);
@@ -369,11 +371,11 @@ Renderer::InitializationData Renderer::initSceneObjects(const SAssetBundle& mesh
 							vertexInput.attributes[normalAttr].format = EF_R32_UINT;
 							for (auto i=0u; i<approxVxCount; i++)
 							{
-								meshBuffer->getAttribute(&dst[i].nml,normalAttr,i);
+								meshBuffer->getAttribute(&dst[i].normal,normalAttr,i);
 								core::vectorSIMDf uv;
 								meshBuffer->getAttribute(uv,2u,i);
-								dst[i].u = core::Float16Compressor::compress(uv.x);
-								dst[i].v = core::Float16Compressor::compress(uv.y);
+								dst[i].u = uv.x;
+								dst[i].v = uv.y;
 							}
 						}
 

--- a/22.RaytracedAO/virtualGeometry.glsl
+++ b/22.RaytracedAO/virtualGeometry.glsl
@@ -27,15 +27,16 @@ vec3 nbl_glsl_fetchVtxPos(in uint vtxID, in nbl_glsl_ext_Mitsuba_Loader_instance
 vec3 nbl_glsl_fetchVtxNormal(in uint vtxID, in nbl_glsl_ext_Mitsuba_Loader_instance_data_t batchInstanceData)
 {
     nbl_glsl_VG_VirtualAttributePacked_t va = batchInstanceData.determinantSignBit;
-    const uint codedNormal = nbl_glsl_VG_attribFetch2u(va,vtxID)[0];
+    const uint codedNormal = nbl_glsl_VG_attribFetch3u(va,vtxID)[0];
     return normalize(nbl_glsl_decodeRGB10A2_SNORM(codedNormal).xyz);
 }
 
 vec2 nbl_glsl_fetchVtxUV(in uint vtxID, in nbl_glsl_ext_Mitsuba_Loader_instance_data_t batchInstanceData)
 {
     nbl_glsl_VG_VirtualAttributePacked_t va = batchInstanceData.determinantSignBit;
-    const uint codedUV = nbl_glsl_VG_attribFetch2u(va,vtxID)[1];
-    return unpackHalf2x16(codedUV).xy;
+    const vec2 codedUV = nbl_glsl_VG_attribFetch3u(va,vtxID).yz;
+
+    return codedUV;
 }
 
 

--- a/22.RaytracedAO/virtualGeometry.glsl
+++ b/22.RaytracedAO/virtualGeometry.glsl
@@ -34,9 +34,8 @@ vec3 nbl_glsl_fetchVtxNormal(in uint vtxID, in nbl_glsl_ext_Mitsuba_Loader_insta
 vec2 nbl_glsl_fetchVtxUV(in uint vtxID, in nbl_glsl_ext_Mitsuba_Loader_instance_data_t batchInstanceData)
 {
     nbl_glsl_VG_VirtualAttributePacked_t va = batchInstanceData.determinantSignBit;
-    const vec2 codedUV = nbl_glsl_VG_attribFetch3u(va,vtxID).yz;
-
-    return codedUV;
+    const uvec2 codedUV = nbl_glsl_VG_attribFetch3u(va,vtxID).yz;
+    return vec2(uintBitsToFloat(codedUV.x), uintBitsToFloat(codedUV.y));
 }
 
 


### PR DESCRIPTION
increase floating point precision which lead us to issues with barycentrics