### PR TITLE
Refactoring accessor usage in examples

### DIFF
--- a/10_CountingSort/app_resources/prefix_sum_shader.comp.hlsl
+++ b/10_CountingSort/app_resources/prefix_sum_shader.comp.hlsl
@@ -11,9 +11,9 @@ groupshared uint32_t sdata[BucketCount];
 
 struct SharedAccessor
 {
-    uint32_t get(const uint32_t index)
+    void get(const uint32_t index, NBL_REF_ARG(uint32_t) value)
     {
-        return sdata[index];
+        value = sdata[index];
     }
 
     void set(const uint32_t index, const uint32_t value)
@@ -46,7 +46,7 @@ void main(uint32_t3 ID : SV_GroupThreadID, uint32_t3 GroupID : SV_GroupID)
     params.minimum = pushData.minimum;
     params.maximum = pushData.maximum;
 
-    using Counter = nbl::hlsl::sort::counting < WorkgroupSize, BucketCount, PtrAccessor, PtrAccessor, PtrAccessor, SharedAccessor>;
+    using Counter = nbl::hlsl::sort::counting < WorkgroupSize, BucketCount, PtrAccessor, PtrAccessor, PtrAccessor, SharedAccessor, PtrAccessor::type_t>;
     Counter counter = Counter::create(nbl::hlsl::glsl::gl_WorkGroupID().x);
 
     const Ptr input_ptr = Ptr::create(pushData.inputKeyAddress);

--- a/10_CountingSort/app_resources/scatter_shader.comp.hlsl
+++ b/10_CountingSort/app_resources/scatter_shader.comp.hlsl
@@ -11,9 +11,9 @@ groupshared uint32_t sdata[BucketCount];
 
 struct SharedAccessor
 {
-    uint32_t get(const uint32_t index)
+    void get(const uint32_t index, NBL_REF_ARG(uint32_t) value)
     {
-        return sdata[index];
+        value = sdata[index];
     }
 
     void set(const uint32_t index, const uint32_t value)
@@ -34,6 +34,7 @@ struct SharedAccessor
 
 struct DoublePtrAccessor
 {
+    using type_t = uint32_t;
     static DoublePtrAccessor create(const PtrAccessor input, const PtrAccessor output)
     {
         DoublePtrAccessor accessor;
@@ -42,9 +43,9 @@ struct DoublePtrAccessor
         return accessor;
     }
 
-    uint32_t get(const uint64_t index)
+    void get(const uint64_t index, NBL_REF_ARG(uint32_t) value)
     {
-        return input.get(index);
+        input.get(index, value);
     }
 
     void set(const uint64_t index, const uint32_t value)
@@ -69,7 +70,7 @@ void main(uint32_t3 ID : SV_GroupThreadID, uint32_t3 GroupID : SV_GroupID)
     params.minimum = pushData.minimum;
     params.maximum = pushData.maximum;
 
-    using Counter = nbl::hlsl::sort::counting < WorkgroupSize, BucketCount, DoublePtrAccessor, DoublePtrAccessor, PtrAccessor, SharedAccessor>;
+    using Counter = nbl::hlsl::sort::counting < WorkgroupSize, BucketCount, DoublePtrAccessor, DoublePtrAccessor, PtrAccessor, SharedAccessor, DoublePtrAccessor::type_t>;
     Counter counter = Counter::create(nbl::hlsl::glsl::gl_WorkGroupID().x);
 
     const Ptr input_key_ptr = Ptr::create(pushData.inputKeyAddress);

--- a/23_ArithmeticUnitTest/app_resources/testWorkgroup.comp.hlsl
+++ b/23_ArithmeticUnitTest/app_resources/testWorkgroup.comp.hlsl
@@ -17,9 +17,9 @@ groupshared uint32_t scratch[ScratchSz];
 template<uint16_t offset>
 struct ScratchProxy
 {
-	uint32_t get(const uint32_t ix)
+	void get(const uint32_t ix, NBL_REF_ARG(uint32_t) value)
 	{
-		return scratch[ix+offset];
+		value = scratch[ix+offset];
 	}
 	void set(const uint32_t ix, const uint32_t value)
 	{


### PR DESCRIPTION
Changing to use the `void get(index, value)` convention