### PR TITLE
Fix GPU benchmark submit chunking

### DIFF
--- a/37_HLSLSamplingTests/benchmarks/CDiscreteSamplerBenchmark.h
+++ b/37_HLSLSamplingTests/benchmarks/CDiscreteSamplerBenchmark.h
@@ -198,7 +198,9 @@ class CDiscreteSamplerBenchmark : public GPUBenchmark
       // Pipeline + push constants are bound *once* in bindOnce, the inner loop is just
       // dispatch(...). Putting binds inside dispatchOne would inflate ps/sample on the
       // tighter samplers.
-      const PipelineEntry& pe = m_pipelines[m_pipelineIdx[size_t(kind)]];
+      const PipelineEntry* pe = getPipelineEntry(m_pipelineIdx[size_t(kind)], joinName(name));
+      if (!pe)
+         return;
 
       const TimingResult timingResult = runTimedBudgeted(warmupIterations, getTargetBudgetMs(),
          [&](IGPUCommandBuffer* cb)
@@ -210,7 +212,7 @@ class CDiscreteSamplerBenchmark : public GPUBenchmark
                pc.pdfAddress                 = m_aliasPdfBuf->getDeviceAddress();
                pc.outputAddress              = m_outputBuf->getDeviceAddress();
                pc.tableSize                  = m_aliasTableN;
-               defaultBindAndPush(cb, pe, pc);
+               defaultBindAndPush(cb, *pe, pc);
             }
             else
             {
@@ -219,13 +221,13 @@ class CDiscreteSamplerBenchmark : public GPUBenchmark
                pc.cumProbAddress        = buf->getDeviceAddress();
                pc.outputAddress         = m_outputBuf->getDeviceAddress();
                pc.tableSize             = N;
-               defaultBindAndPush(cb, pe, pc);
+               defaultBindAndPush(cb, *pe, pc);
             }
          },
          [this](IGPUCommandBuffer* cb) { defaultDispatch(cb); },
          samplesForCurrentRow());
 
-      record(std::move(name), timingResult, pe.stats);
+      record(std::move(name), timingResult, pe->stats);
    }
 
    core::smart_refctd_ptr<IAssetManager> m_assetMgr;

--- a/37_HLSLSamplingTests/benchmarks/CSamplerBenchmark.h
+++ b/37_HLSLSamplingTests/benchmarks/CSamplerBenchmark.h
@@ -39,16 +39,18 @@ class CSamplerBenchmark : public GPUBenchmark
 
    void doRun() override
    {
-      const PipelineEntry&      pe = m_pipelines[m_pipelineIdx];
+      const PipelineEntry*      pe = getPipelineEntry(m_pipelineIdx, joinName(m_name));
+      if (!pe)
+         return;
       SamplerBenchPushConstants pc = {};
       pc.outputAddress             = m_outputAddress;
 
       const TimingResult t = runTimedBudgeted(getWarmupDispatches(), getTargetBudgetMs(),
-         [&](video::IGPUCommandBuffer* cb) { defaultBindAndPush(cb, pe, pc); },
+         [&](video::IGPUCommandBuffer* cb) { defaultBindAndPush(cb, *pe, pc); },
          [this](video::IGPUCommandBuffer* cb) { defaultDispatch(cb); },
          samplesForCurrentRow());
 
-      record(m_name, t, pe.stats);
+      record(m_name, t, pe->stats);
    }
 
    private:

--- a/37_HLSLSamplingTests/main.cpp
+++ b/37_HLSLSamplingTests/main.cpp
@@ -52,6 +52,7 @@ using namespace nbl::examples;
 
 #include "benchmarks/CSamplerBenchmark.h"
 #include "benchmarks/CDiscreteSamplerBenchmark.h"
+#include "nbl/examples/Tester/FailureManifest.h"
 #include "tests/property/CSamplerPropertyTester.h"
 
 
@@ -189,6 +190,12 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
 
       m_logger->log("All sampling concept tests passed.", ILogger::ELL_INFO);
 
+      const auto runControl = nbl::examples::testing::parseRunControl(this->argv, m_logger.get());
+      if (!runControl.valid)
+         return false;
+
+      nbl::examples::testing::FailureManifest failureManifest("37_HLSLSamplingTests");
+
       // ======================================================================
       // GPU throughput benchmarks
       // ======================================================================
@@ -197,6 +204,12 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
 
       if constexpr (DoBenchmark)
       {
+         if (runControl.skipBenchmarks)
+         {
+            m_logger->log("Skipping benchmark phase due to CLI.", ILogger::ELL_INFO);
+         }
+         else
+         {
          constexpr uint32_t benchWorkgroupSize      = WORKGROUP_SIZE;
          constexpr uint32_t totalThreadsPerDispatch = benchWorkgroupsCount * benchWorkgroupSize;
          constexpr uint32_t iterationsPerThread     = BENCH_ITERS;
@@ -346,6 +359,7 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
                Aggregator::makeSpan(benchmarks,    samplerCtx),
                Aggregator::makeSpan(discreteBench, discreteCtx));
          }
+         }
       }
 
       // ================================================================
@@ -353,9 +367,16 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
       // ================================================================
       bool pass = true;
       constexpr uint32_t testWorkgroupsCount = 4096;
+      bool samplerPass = true;
       // generic lambda to run a GPU sampler test
-      auto runSamplerTest = [&]<typename Tester, core::StringLiteral ShaderKey>(const char* testName, const char* logFile)
+      auto runSamplerTest = [&]<typename Tester, core::StringLiteral ShaderKey>(const char* id, const char* testName, const char* logFile)
       {
+         if (!runControl.filter.shouldRun(id))
+         {
+            m_logger->log("Skipping %s tests due to filter.", ILogger::ELL_INFO, testName);
+            return;
+         }
+
          m_logger->log("Running %s tests...", ILogger::ELL_INFO, testName);
          typename Tester::PipelineSetupData data;
          data.device             = m_device;
@@ -367,43 +388,58 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
          data.shaderKey          = std::move(nbl::this_example::builtin::build::get_spirv_key<ShaderKey>(m_device.get()));
          Tester tester(testWorkgroupsCount);
          tester.setupPipeline(data);
-         pass &= tester.performTestsAndVerifyResults(logFile);
+         if (const auto seed = runControl.filter.seedFor(id); seed.has_value())
+            tester.setSeed(*seed);
+         tester.setFailureRecordContext(&failureManifest, "sampler", id, testName);
+         samplerPass &= tester.performTestsAndVerifyResults(logFile);
       };
 
       // --- Sampler tests ---
       if constexpr (true)
       {
-         runSamplerTest.operator()<CLinearTester, "linear_test">("Linear sampler", "LinearTestLog.txt");
-         runSamplerTest.operator()<CBilinearTester, "bilinear_test">("Bilinear sampler", "BilinearTestLog.txt");
-         runSamplerTest.operator()<CUniformHemisphereTester, "uniform_hemisphere_test">("UniformHemisphere sampler", "UniformHemisphereTestLog.txt");
-         runSamplerTest.operator()<CUniformSphereTester, "uniform_sphere_test">("UniformSphere sampler", "UniformSphereTestLog.txt");
-         runSamplerTest.operator()<CProjectedHemisphereTester, "projected_hemisphere_test">("ProjectedHemisphere sampler", "ProjectedHemisphereTestLog.txt");
-         runSamplerTest.operator()<CProjectedSphereTester, "projected_sphere_test">("ProjectedSphere sampler", "ProjectedSphereTestLog.txt");
-         runSamplerTest.operator()<CConcentricMappingTester, "concentric_mapping_test">("ConcentricMapping sampler", "ConcentricMappingTestLog.txt");
-         runSamplerTest.operator()<CPolarMappingTester, "polar_mapping_test">("PolarMapping sampler", "PolarMappingTestLog.txt");
-         runSamplerTest.operator()<CBoxMullerTransformTester, "box_muller_transform_test">("BoxMullerTransform sampler", "BoxMullerTransformTestLog.txt");
-         runSamplerTest.operator()<CSphericalTriangleTester, "spherical_triangle">("SphericalTriangle", "SphericalTriangleTestLog.txt");
-         runSamplerTest.operator()<CProjectedSphericalTriangleTester, "projected_spherical_triangle_test">("ProjectedSphericalTriangle sampler", "ProjectedSphericalTriangleTestLog.txt");
-         runSamplerTest.operator()<CSphericalRectangleTester, "spherical_rectangle_test">("SphericalRectangle sampler", "SphericalRectangleTestLog.txt");
-         runSamplerTest.operator()<CProjectedSphericalRectangleTester, "projected_spherical_rectangle_test">("ProjectedSphericalRectangle sampler", "ProjectedSphericalRectangleTestLog.txt");
+         runSamplerTest.operator()<CLinearTester, "linear_test">("sampler/Linear", "Linear sampler", "LinearTestLog.txt");
+         runSamplerTest.operator()<CBilinearTester, "bilinear_test">("sampler/Bilinear", "Bilinear sampler", "BilinearTestLog.txt");
+         runSamplerTest.operator()<CUniformHemisphereTester, "uniform_hemisphere_test">("sampler/UniformHemisphere", "UniformHemisphere sampler", "UniformHemisphereTestLog.txt");
+         runSamplerTest.operator()<CUniformSphereTester, "uniform_sphere_test">("sampler/UniformSphere", "UniformSphere sampler", "UniformSphereTestLog.txt");
+         runSamplerTest.operator()<CProjectedHemisphereTester, "projected_hemisphere_test">("sampler/ProjectedHemisphere", "ProjectedHemisphere sampler", "ProjectedHemisphereTestLog.txt");
+         runSamplerTest.operator()<CProjectedSphereTester, "projected_sphere_test">("sampler/ProjectedSphere", "ProjectedSphere sampler", "ProjectedSphereTestLog.txt");
+         runSamplerTest.operator()<CConcentricMappingTester, "concentric_mapping_test">("sampler/ConcentricMapping", "ConcentricMapping sampler", "ConcentricMappingTestLog.txt");
+         runSamplerTest.operator()<CPolarMappingTester, "polar_mapping_test">("sampler/PolarMapping", "PolarMapping sampler", "PolarMappingTestLog.txt");
+         runSamplerTest.operator()<CBoxMullerTransformTester, "box_muller_transform_test">("sampler/BoxMullerTransform", "BoxMullerTransform sampler", "BoxMullerTransformTestLog.txt");
+         runSamplerTest.operator()<CSphericalTriangleTester, "spherical_triangle">("sampler/SphericalTriangle", "SphericalTriangle", "SphericalTriangleTestLog.txt");
+         runSamplerTest.operator()<CProjectedSphericalTriangleTester, "projected_spherical_triangle_test">("sampler/ProjectedSphericalTriangle", "ProjectedSphericalTriangle sampler", "ProjectedSphericalTriangleTestLog.txt");
+         runSamplerTest.operator()<CSphericalRectangleTester, "spherical_rectangle_test">("sampler/SphericalRectangle", "SphericalRectangle sampler", "SphericalRectangleTestLog.txt");
+         runSamplerTest.operator()<CProjectedSphericalRectangleTester, "projected_spherical_rectangle_test">("sampler/ProjectedSphericalRectangle", "ProjectedSphericalRectangle sampler", "ProjectedSphericalRectangleTestLog.txt");
       }
 
       if constexpr (true)
       {
          // --- Discrete table construction (CPU) ---
          {
-            m_logger->log("Running discrete table builder tests (CPU)...", ILogger::ELL_INFO);
-            CDiscreteTableTester tableTester(m_logger.get());
-            pass &= tableTester.run();
+            constexpr const char* id = "sampler/DiscreteTableBuilder";
+            if (!runControl.filter.shouldRun(id))
+            {
+               m_logger->log("Skipping discrete table builder tests due to filter.", ILogger::ELL_INFO);
+            }
+            else
+            {
+               m_logger->log("Running discrete table builder tests (CPU)...", ILogger::ELL_INFO);
+               CDiscreteTableTester tableTester(m_logger.get());
+               const bool ok = tableTester.run();
+               samplerPass &= ok;
+               if (!ok)
+                  failureManifest.addGroupFailure("sampler", id, "Discrete table builder");
+            }
          }
 
          // --- GPU table sampler tests ---
-         runSamplerTest.operator()<CPackedAliasAGPUTester, "packed_alias_a_test">("PackedAliasA GPU sampler", "PackedAliasATestLog.txt");
-         runSamplerTest.operator()<CPackedAliasBGPUTester, "packed_alias_b_test">("PackedAliasB GPU sampler", "PackedAliasBTestLog.txt");
-         runSamplerTest.operator()<CCumulativeProbabilityGPUTester, "cumulative_probability_test">("CumulativeProbability GPU sampler", "CumulativeProbabilityTestLog.txt");
+         runSamplerTest.operator()<CPackedAliasAGPUTester, "packed_alias_a_test">("sampler/PackedAliasA", "PackedAliasA GPU sampler", "PackedAliasATestLog.txt");
+         runSamplerTest.operator()<CPackedAliasBGPUTester, "packed_alias_b_test">("sampler/PackedAliasB", "PackedAliasB GPU sampler", "PackedAliasBTestLog.txt");
+         runSamplerTest.operator()<CCumulativeProbabilityGPUTester, "cumulative_probability_test">("sampler/CumulativeProbability", "CumulativeProbability GPU sampler", "CumulativeProbabilityTestLog.txt");
       }
       logJacobianSkipCounts(m_logger.get());
-      if (pass)
+      pass &= samplerPass;
+      if (samplerPass)
          m_logger->log("All sampling tests PASSED.", ILogger::ELL_INFO);
       else
          m_logger->log("Some sampling tests FAILED. Check log files for details.", ILogger::ELL_ERROR);
@@ -413,12 +449,28 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
       // ================================================================
       if constexpr (true)
       {
+         bool propertyPass = true;
          m_logger->log("Running sampler property tests (CPU)...", ILogger::ELL_INFO);
          m_logger->log("WARNING: CPU math may use higher intermediate precision than GPU shaders. Tolerances that pass here may be too tight for GPU.", ILogger::ELL_WARNING);
 
          auto check = [&]<typename Config>()
          {
-            pass &= CSamplerPropertyTester<Config>(m_logger.get()).run();
+            const std::string id = std::string("property/") + Config::name();
+            if (!runControl.filter.shouldRun(id))
+            {
+               m_logger->log("Skipping %s property tests due to filter.", ILogger::ELL_INFO, Config::name());
+               return;
+            }
+
+            CSamplerPropertyTester<Config> tester(m_logger.get(), runControl.filter.seedFor(id));
+            const bool ok = tester.run();
+            propertyPass &= ok;
+            if (!ok)
+            {
+               failureManifest.addGroupFailure("property", id, Config::name());
+               if (const auto seed = tester.failureSeed(); seed.has_value())
+                  failureManifest.addCase("property", id, Config::name(), "property", "CPU", 0, *seed, 0.0, 0.0);
+            }
          };
 
          check.operator()<LinearPropertyConfig>();
@@ -444,7 +496,8 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
          // Grazing angle tests
          check.operator()<ProjectedSphericalTriangleGrazingConfig>();
 
-         if (pass)
+         pass &= propertyPass;
+         if (propertyPass)
             m_logger->log("All sampler property tests PASSED.", ILogger::ELL_INFO);
          else
             m_logger->log("Some sampler property tests FAILED.", ILogger::ELL_ERROR);
@@ -455,26 +508,40 @@ class HLSLSamplingTests final : public application_templates::MonoDeviceApplicat
       // ================================================================
       if constexpr (true)
       {
+         bool geometryPass = true;
          m_logger->log("Running geometry tests (CPU)...", ILogger::ELL_INFO);
          m_logger->log("WARNING: CPU math may use higher intermediate precision than GPU shaders. Tolerances that pass here may be too tight for GPU.", ILogger::ELL_WARNING);
 
-         auto check = [&]<typename Tester>()
+         auto check = [&]<typename Tester>(const char* id, const char* name)
          {
-            pass &= Tester(m_logger.get()).run();
+            if (!runControl.filter.shouldRun(id))
+            {
+               m_logger->log("Skipping %s geometry tests due to filter.", ILogger::ELL_INFO, name);
+               return;
+            }
+
+            const bool ok = Tester(m_logger.get()).run();
+            geometryPass &= ok;
+            if (!ok)
+               failureManifest.addGroupFailure("geometry", id, name);
          };
 
-         check.template operator()<CSolidAngleAccuracyTester>();
-         check.template operator()<CSphericalTriangleGenerateTester>();
-         check.template operator()<CSphericalRectangleGenerateTester>();
-         check.template operator()<CProjectedSphericalRectangleGenerateTester>();
-         check.template operator()<CProjectedSphericalRectangleGeometricTester>();
-         check.template operator()<CProjectedSphericalTriangleGeometricTester>();
+         check.template operator()<CSolidAngleAccuracyTester>("geometry/SolidAngleAccuracy", "SolidAngleAccuracy");
+         check.template operator()<CSphericalTriangleGenerateTester>("geometry/SphericalTriangleGenerate", "SphericalTriangleGenerate");
+         check.template operator()<CSphericalRectangleGenerateTester>("geometry/SphericalRectangleGenerate", "SphericalRectangleGenerate");
+         check.template operator()<CProjectedSphericalRectangleGenerateTester>("geometry/ProjectedSphericalRectangleGenerate", "ProjectedSphericalRectangleGenerate");
+         check.template operator()<CProjectedSphericalRectangleGeometricTester>("geometry/ProjectedSphericalRectangle", "ProjectedSphericalRectangle");
+         check.template operator()<CProjectedSphericalTriangleGeometricTester>("geometry/ProjectedSphericalTriangle", "ProjectedSphericalTriangle");
 
-         if (pass)
+         pass &= geometryPass;
+         if (geometryPass)
             m_logger->log("All geometry tests PASSED.", ILogger::ELL_INFO);
          else
             m_logger->log("Some geometry tests FAILED.", ILogger::ELL_ERROR);
       }
+
+      if (!runControl.failedOutPath.empty())
+         pass &= nbl::examples::testing::writeFailureManifestFile(failureManifest, runControl.failedOutPath, m_logger.get());
 
       return pass;
    }

--- a/37_HLSLSamplingTests/tests/SamplerTestHelpers.h
+++ b/37_HLSLSamplingTests/tests/SamplerTestHelpers.h
@@ -7,6 +7,8 @@
 #include <nbl/builtin/hlsl/shapes/spherical_triangle.hlsl>
 #include <nbl/builtin/hlsl/shapes/spherical_rectangle.hlsl>
 
+#include <optional>
+
 // ============================================================================
 // Declarative field verification helpers
 //
@@ -475,7 +477,7 @@ struct SeededTestContext
    std::mt19937 rng;
    uint32_t failCount = 0;
 
-   SeededTestContext() : seed(std::random_device {}()), rng(seed) {}
+   SeededTestContext(std::optional<uint32_t> seedOverride = {}) : seed(seedOverride.value_or(std::random_device {}())), rng(seed) {}
 
    // Log "reproduce with seed" if failCount > 0, return failCount == 0
    bool finalize(nbl::system::ILogger* logger, const char* tag) const

--- a/37_HLSLSamplingTests/tests/property/CSamplerPropertyTester.h
+++ b/37_HLSLSamplingTests/tests/property/CSamplerPropertyTester.h
@@ -78,7 +78,9 @@ class CSamplerPropertyTester
    }
 
    public:
-   CSamplerPropertyTester(system::ILogger* logger) : m_logger(logger) {}
+   CSamplerPropertyTester(system::ILogger* logger, std::optional<uint32_t> seedOverride = {}) : m_logger(logger), m_seedOverride(seedOverride) {}
+
+   std::optional<uint32_t> failureSeed() const { return m_failureSeed; }
 
    bool run()
    {
@@ -96,7 +98,7 @@ class CSamplerPropertyTester
    // If the PDF normalization is wrong by factor k, this will be off by 1/k.
    bool testMonteCarloPdfNormalization()
    {
-      SeededTestContext ctx;
+      SeededTestContext ctx(m_seedOverride);
       uint32_t evaluatedConfigs = 0;
 
       for (uint32_t c = 0; c < Config::numConfigurations; c++)
@@ -159,7 +161,10 @@ class CSamplerPropertyTester
          m_logger->log("  [%s] MC normalization FAILED (%u/%u evaluated configs failed, %u/%u configs evaluated, %u samples/config, relTol=%e)",
             system::ILogger::ELL_ERROR, Config::name(), ctx.failCount, evaluatedConfigs, evaluatedConfigs, Config::numConfigurations, Config::samplesPerConfig, Config::mcNormalizationRelTol);
 
-      return ctx.finalize(m_logger, Config::name());
+      const bool passed = ctx.finalize(m_logger, Config::name());
+      if (!passed)
+         m_failureSeed = ctx.seed;
+      return passed;
    }
 
    // Test 4: Grid integration of backwardPdf over [0,1]^d codomain
@@ -167,7 +172,7 @@ class CSamplerPropertyTester
    // integral of backwardPdf over codomain should equal 1.0.
    bool testGridPdfNormalization()
    {
-      SeededTestContext ctx;
+      SeededTestContext ctx(m_seedOverride);
 
       for (uint32_t c = 0; c < Config::numConfigurations; c++)
       {
@@ -191,10 +196,15 @@ class CSamplerPropertyTester
          m_logger->log("  [%s] grid PDF normalization FAILED (%u/%u configs exceeded absTol=%e)",
             system::ILogger::ELL_ERROR, Config::name(), ctx.failCount, Config::numConfigurations, Config::gridNormalizationAbsTol);
 
-      return ctx.finalize(m_logger, Config::name());
+      const bool passed = ctx.finalize(m_logger, Config::name());
+      if (!passed)
+         m_failureSeed = ctx.seed;
+      return passed;
    }
 
    system::ILogger* m_logger;
+   std::optional<uint32_t> m_seedOverride;
+   std::optional<uint32_t> m_failureSeed;
 };
 
 

--- a/64_EmulatedFloatTest/main.cpp
+++ b/64_EmulatedFloatTest/main.cpp
@@ -91,20 +91,22 @@ class CEF64Benchmark : public GPUBenchmark
 
    void doRun() override
    {
-      const PipelineEntry&   pe = m_pipelines[m_pipelineIdx];
+      const PipelineEntry*   pe = getPipelineEntry(m_pipelineIdx, joinName(m_name));
+      if (!pe)
+         return;
       BenchmarkPushConstants pc = {};
       pc.benchmarkMode          = m_mode;
 
       const TimingResult t = runTimedBudgeted(getWarmupDispatches(), getTargetBudgetMs(),
          [&](IGPUCommandBuffer* cb)
          {
-            cb->bindDescriptorSets(EPBP_COMPUTE, pe.layout.get(), 0, 1, &m_ds.get());
-            defaultBindAndPush(cb, pe, pc);
+            cb->bindDescriptorSets(EPBP_COMPUTE, pe->layout.get(), 0, 1, &m_ds.get());
+            defaultBindAndPush(cb, *pe, pc);
          },
          [this](IGPUCommandBuffer* cb) { defaultDispatch(cb); },
          samplesForCurrentRow());
 
-      record(m_name, t, pe.stats);
+      record(m_name, t, pe->stats);
    }
 
    private:

--- a/common/include/nbl/examples/Benchmark/BenchmarkJson.h
+++ b/common/include/nbl/examples/Benchmark/BenchmarkJson.h
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -85,32 +86,52 @@ inline std::optional<Baseline> loadBaselineFile(std::string label, const std::st
          continue;
          
       BaselineRow row;
-      row.psPerSample     = ps->get<double>();
-      row.registerCount   = r.at("regs").get<uint64_t>();
-      row.codeSizeBytes   = r.at("code_bytes").get<uint64_t>();
-      row.sharedMemBytes  = r.at("shared_mem_bytes").get<uint64_t>();
-      row.privateMemBytes = r.at("local_mem_bytes").get<uint64_t>();
-      row.stackBytes      = r.at("stack_bytes").get<uint64_t>();
-      row.subgroupSize    = r.at("subgroup_size").get<uint64_t>();
+      try
+      {
+         row.psPerSample = ps->get<double>();
+      }
+      catch (const std::exception&)
+      {
+         continue;
+      }
+
+      auto readU64 = [&](const char* key, uint64_t& out)
+      {
+         const auto it = r.find(key);
+         if (it != r.end() && it->is_number_unsigned())
+            out = it->get<uint64_t>();
+      };
+      readU64("regs", row.registerCount);
+      readU64("code_bytes", row.codeSizeBytes);
+      readU64("shared_mem_bytes", row.sharedMemBytes);
+      readU64("local_mem_bytes", row.privateMemBytes);
+      readU64("stack_bytes", row.stackBytes);
+      readU64("subgroup_size", row.subgroupSize);
 
       auto readUvec3 = [&](const char* key, nbl::hlsl::uint32_t3& out)
       {
-         const auto& a = r.at(key);
-         out.x         = a[0].get<uint32_t>();
-         out.y         = a[1].get<uint32_t>();
-         out.z         = a[2].get<uint32_t>();
+         const auto it = r.find(key);
+         if (it == r.end() || !it->is_array() || it->size() != 3)
+            return;
+         const auto& a = *it;
+         if (!a[0].is_number_unsigned() || !a[1].is_number_unsigned() || !a[2].is_number_unsigned())
+            return;
+         out.x = a[0].get<uint32_t>();
+         out.y = a[1].get<uint32_t>();
+         out.z = a[2].get<uint32_t>();
       };
       readUvec3("workgroup_size", row.workload.shape.workgroupSize);
       readUvec3("dispatch_groups", row.workload.shape.dispatchGroupCount);
-      row.workload.shape.samplesPerDispatch = r.at("samples_per_dispatch").get<uint64_t>();
-      row.workload.benchDispatches          = r.at("bench_dispatches").get<uint32_t>();
+      readU64("samples_per_dispatch", row.workload.shape.samplesPerDispatch);
+      if (const auto it = r.find("bench_dispatches"); it != r.end() && it->is_number_unsigned())
+         row.workload.benchDispatches = it->get<uint32_t>();
 
       rowsByName[makeKey(nameVec)] = row;
    }
    if (rowsByName.empty())
       return std::nullopt;
 
-   return Baseline {std::move(label), path, j.at("device"), std::move(rowsByName)};
+   return Baseline {std::move(label), path, j.contains("device") ? j["device"] : nullptr, std::move(rowsByName)};
 }
 
 // Writes a JSON report. Preserves rows in the prior file whose names weren't

--- a/common/include/nbl/examples/Benchmark/GPUBenchmarkHelper.h
+++ b/common/include/nbl/examples/Benchmark/GPUBenchmarkHelper.h
@@ -12,7 +12,9 @@
 #include "nbl/asset/utils/IShaderCompiler.h"
 
 #include <algorithm>
+#include <cmath>
 #include <functional>
+#include <limits>
 #include <ranges>
 #include <span>
 #include <string>
@@ -71,8 +73,8 @@ public:
       bool isPrecompiled() const { return !precompiledKey.empty(); }
    };
 
-   // Layout: [bindOnce] [warmup x dispatchOne][ts0][bench x dispatchOne][ts1][cooldown x dispatchOne]
-   // Cooldown == warmup so the measured window isn't on a winding-down tail.
+   // Logical layout: [warmup x dispatchOne][ts0][bench x dispatchOne][ts1][cooldown x dispatchOne]
+   // Warmup/cooldown can be split into shorter submissions and the measured window stays intact.
    // Putting binds inside dispatchOne adds per-iteration cmdbuf overhead that
    // shows up in ps/sample on tight shaders.
    using DispatchFn = std::function<void(nbl::video::IGPUCommandBuffer*)>;
@@ -513,8 +515,22 @@ public:
       const uint64_t     targetBudgetNs = targetBudgetMs * 1'000'000ull;
       constexpr uint32_t kPilotN        = 64;
       constexpr uint32_t kMaxN          = 1u << 24; // safety cap for ultra-fast shaders
-      TimingResult       r              = runTimed(warmupDispatches, kPilotN, bindOnce, dispatchOne);
+      uint32_t           dispatchesPerSubmit = 1u;
+      TimingResult       r                   = runTimed(warmupDispatches, kPilotN, bindOnce, dispatchOne, dispatchesPerSubmit);
+      dispatchesPerSubmit                    = estimateDispatchesPerSubmit(r, kPilotN);
       uint32_t           lastN          = kPilotN;
+      while (r.elapsed_ns > targetBudgetNs && lastN > 1u)
+      {
+         const double scale = double(targetBudgetNs) / r.elapsed_ns;
+         uint32_t     nextN = uint32_t(std::max(1.0, std::floor(double(lastN) * scale)));
+         if (nextN >= lastN)
+            nextN = lastN - 1u;
+
+         r                   = runTimed(warmupDispatches, nextN, bindOnce, dispatchOne, dispatchesPerSubmit);
+         dispatchesPerSubmit = estimateDispatchesPerSubmit(r, nextN);
+         lastN               = nextN;
+      }
+
       while (r.elapsed_ns < targetBudgetNs && lastN < kMaxN)
       {
          uint32_t nextN;
@@ -529,8 +545,9 @@ public:
          }
          if (nextN <= lastN)
             break; // converged
-         r     = runTimed(warmupDispatches, nextN, bindOnce, dispatchOne);
-         lastN = nextN;
+         r                   = runTimed(warmupDispatches, nextN, bindOnce, dispatchOne, dispatchesPerSubmit);
+         dispatchesPerSubmit = estimateDispatchesPerSubmit(r, nextN);
+         lastN               = nextN;
       }
 
       if (samples <= 1)
@@ -545,7 +562,7 @@ public:
       ns.push_back(r.elapsed_ns);
       for (uint32_t i = 1; i < samples; ++i)
       {
-         const TimingResult ri = runTimed(warmupDispatches, lastN, bindOnce, dispatchOne);
+         const TimingResult ri = runTimed(warmupDispatches, lastN, bindOnce, dispatchOne, dispatchesPerSubmit);
          ns.push_back(ri.elapsed_ns);
       }
       std::sort(ns.begin(), ns.end());
@@ -580,48 +597,53 @@ public:
       return m;
    }
 
-   TimingResult runTimed(uint32_t warmupDispatches, uint32_t benchDispatches, const DispatchFn& bindOnce, const DispatchFn& dispatchOne)
+   TimingResult runTimed(uint32_t warmupDispatches, uint32_t benchDispatches, const DispatchFn& bindOnce, const DispatchFn& dispatchOne, uint32_t maxDispatchesPerSubmit)
    {
-      m_device->waitIdle();
+      if (m_device->waitIdle() != nbl::video::IQueue::RESULT::SUCCESS)
+         return {};
+
       const uint32_t cooldownDispatches = warmupDispatches;
 
-      m_cmdbuf->reset(nbl::video::IGPUCommandBuffer::RESET_FLAGS::NONE);
-      m_cmdbuf->begin(nbl::video::IGPUCommandBuffer::USAGE::ONE_TIME_SUBMIT_BIT);
-      m_cmdbuf->resetQueryPool(m_queryPool.get(), 0, 2);
+      if (!runUntimedDispatches(warmupDispatches, bindOnce, dispatchOne, maxDispatchesPerSubmit))
+         return {};
 
-      if (bindOnce)
-         bindOnce(m_cmdbuf.get());
+      double   elapsedNs = 0.0;
+      uint32_t remaining = benchDispatches;
+      while (remaining > 0u)
+      {
+         const uint32_t batch = std::min(remaining, std::max(1u, maxDispatchesPerSubmit));
 
-      for (uint32_t i = 0u; i < warmupDispatches; ++i)
-         dispatchOne(m_cmdbuf.get());
+         m_cmdbuf->reset(nbl::video::IGPUCommandBuffer::RESET_FLAGS::NONE);
+         m_cmdbuf->begin(nbl::video::IGPUCommandBuffer::USAGE::ONE_TIME_SUBMIT_BIT);
+         m_cmdbuf->resetQueryPool(m_queryPool.get(), 0, 2);
 
-      m_cmdbuf->writeTimestamp(nbl::asset::PIPELINE_STAGE_FLAGS::COMPUTE_SHADER_BIT, m_queryPool.get(), 0);
-      for (uint32_t i = 0u; i < benchDispatches; ++i)
-         dispatchOne(m_cmdbuf.get());
-      m_cmdbuf->writeTimestamp(nbl::asset::PIPELINE_STAGE_FLAGS::COMPUTE_SHADER_BIT, m_queryPool.get(), 1);
+         if (bindOnce)
+            bindOnce(m_cmdbuf.get());
 
-      for (uint32_t i = 0u; i < cooldownDispatches; ++i)
-         dispatchOne(m_cmdbuf.get());
-      m_cmdbuf->end();
+         m_cmdbuf->writeTimestamp(nbl::asset::PIPELINE_STAGE_FLAGS::COMPUTE_SHADER_BIT, m_queryPool.get(), 0);
+         for (uint32_t i = 0u; i < batch; ++i)
+            dispatchOne(m_cmdbuf.get());
+         m_cmdbuf->writeTimestamp(nbl::asset::PIPELINE_STAGE_FLAGS::COMPUTE_SHADER_BIT, m_queryPool.get(), 1);
+         m_cmdbuf->end();
 
-      auto                                                      semaphore   = m_device->createSemaphore(0u);
-      const nbl::video::IQueue::SSubmitInfo::SCommandBufferInfo benchCmds[] = {{.cmdbuf = m_cmdbuf.get()}};
-      const nbl::video::IQueue::SSubmitInfo::SSemaphoreInfo     signalSem[] = {
-         {.semaphore = semaphore.get(), .value = 1u, .stageMask = nbl::asset::PIPELINE_STAGE_FLAGS::COMPUTE_SHADER_BIT}};
-      nbl::video::IQueue::SSubmitInfo submit = {};
-      submit.commandBuffers                  = benchCmds;
-      submit.signalSemaphores                = signalSem;
-      m_queue->submit({&submit, 1u});
+         if (!submitAndWait())
+            return {};
 
-      m_device->waitIdle();
+         uint64_t   timestamps[2] = {};
+         const auto flags         = nbl::core::bitflag(nbl::video::IQueryPool::RESULTS_FLAGS::_64_BIT) | nbl::core::bitflag(nbl::video::IQueryPool::RESULTS_FLAGS::WAIT_BIT);
+         if (!m_device->getQueryPoolResults(m_queryPool.get(), 0, 2, timestamps, sizeof(uint64_t), flags))
+            return {};
 
-      uint64_t   timestamps[2] = {};
-      const auto flags         = nbl::core::bitflag(nbl::video::IQueryPool::RESULTS_FLAGS::_64_BIT) | nbl::core::bitflag(nbl::video::IQueryPool::RESULTS_FLAGS::WAIT_BIT);
-      m_device->getQueryPoolResults(m_queryPool.get(), 0, 2, timestamps, sizeof(uint64_t), flags);
+         const double timestampPeriod = double(m_physicalDevice->getLimits().timestampPeriodInNanoSeconds);
+         elapsedNs += double(timestamps[1] - timestamps[0]) * timestampPeriod;
+         remaining -= batch;
+      }
+
+      if (!runUntimedDispatches(cooldownDispatches, bindOnce, dispatchOne, maxDispatchesPerSubmit))
+         return {};
 
       TimingResult r {};
-      const double timestampPeriod = double(m_physicalDevice->getLimits().timestampPeriodInNanoSeconds);
-      r.elapsed_ns                 = double(timestamps[1] - timestamps[0]) * timestampPeriod;
+      r.elapsed_ns                 = elapsedNs;
       r.totalSamples               = uint64_t(benchDispatches) * m_samplesPerDispatch;
       r.ps_per_sample              = r.totalSamples ? r.elapsed_ns * 1e3 / double(r.totalSamples) : 0.0;
       r.gsamples_per_s             = r.elapsed_ns > 0.0 ? double(r.totalSamples) / r.elapsed_ns : 0.0;
@@ -633,6 +655,63 @@ protected:
    std::vector<PipelineEntry> m_pipelines;
 
 private:
+   // Soft target for one queue submit, estimated from timings on the current GPU.
+   // Benchmark budgets still control measured work. This only chunks submits.
+   static constexpr double SubmitChunkTargetNs = 250'000'000.0;
+
+   static uint32_t estimateDispatchesPerSubmit(const TimingResult& r, uint32_t dispatches)
+   {
+      if (dispatches == 0u || r.elapsed_ns <= 0.0)
+         return 1u;
+
+      const double nsPerDispatch = r.elapsed_ns / double(dispatches);
+      if (nsPerDispatch <= 0.0)
+         return 1u;
+
+      const double maxDispatches = std::floor(SubmitChunkTargetNs / nsPerDispatch);
+      return uint32_t(std::clamp(maxDispatches, 1.0, double(std::numeric_limits<uint32_t>::max())));
+   }
+
+   bool submitAndWait()
+   {
+      auto semaphore = m_device->createSemaphore(0u);
+      if (!semaphore)
+         return false;
+
+      const nbl::video::IQueue::SSubmitInfo::SCommandBufferInfo cmds[] = {{.cmdbuf = m_cmdbuf.get()}};
+      const nbl::video::IQueue::SSubmitInfo::SSemaphoreInfo     done[] = {
+         {.semaphore = semaphore.get(), .value = 1u, .stageMask = nbl::asset::PIPELINE_STAGE_FLAGS::ALL_COMMANDS_BITS}};
+      nbl::video::IQueue::SSubmitInfo submit = {};
+      submit.commandBuffers                  = cmds;
+      submit.signalSemaphores                = done;
+      if (m_queue->submit({&submit, 1u}) != nbl::video::IQueue::RESULT::SUCCESS)
+         return false;
+
+      const nbl::video::ISemaphore::SWaitInfo wait[] = {{.semaphore = semaphore.get(), .value = 1u}};
+      return m_device->blockForSemaphores(wait) == nbl::video::ISemaphore::WAIT_RESULT::SUCCESS;
+   }
+
+   bool runUntimedDispatches(uint32_t dispatches, const DispatchFn& bindOnce, const DispatchFn& dispatchOne, uint32_t maxDispatchesPerSubmit)
+   {
+      while (dispatches > 0u)
+      {
+         const uint32_t batch = std::min(dispatches, std::max(1u, maxDispatchesPerSubmit));
+
+         m_cmdbuf->reset(nbl::video::IGPUCommandBuffer::RESET_FLAGS::NONE);
+         m_cmdbuf->begin(nbl::video::IGPUCommandBuffer::USAGE::ONE_TIME_SUBMIT_BIT);
+         if (bindOnce)
+            bindOnce(m_cmdbuf.get());
+         for (uint32_t i = 0u; i < batch; ++i)
+            dispatchOne(m_cmdbuf.get());
+         m_cmdbuf->end();
+
+         if (!submitAndWait())
+            return false;
+         dispatches -= batch;
+      }
+      return true;
+   }
+
    static void matchStat(const nbl::video::IGPUPipelineBase::SExecutableStatistic& stat, PipelineStats& out, uint64_t& vgpr, uint64_t& sgpr)
    {
       const uint64_t v = stat.asUint();

--- a/common/include/nbl/examples/Benchmark/GPUBenchmarkHelper.h
+++ b/common/include/nbl/examples/Benchmark/GPUBenchmarkHelper.h
@@ -344,9 +344,7 @@ public:
       nbl::core::smart_refctd_ptr<nbl::video::IGPUDescriptorSetLayout> dsLayout = nullptr)
    {
       using namespace nbl;
-      const uint32_t idx = uint32_t(m_pipelines.size());
-      m_pipelines.push_back({.tag = tag});
-      PipelineEntry& slot = m_pipelines.back();
+      PipelineEntry slot = {.tag = tag};
 
       const asset::SPushConstantRange pcRange = {
          .stageFlags = asset::IShader::E_SHADER_STAGE::ESS_COMPUTE,
@@ -359,7 +357,7 @@ public:
       if (!layout)
       {
          benchLogFmt(m_logger.get(), system::ILogger::ELL_ERROR, "createPipeline({}): pipeline layout creation failed", tag);
-         return idx;
+         return InvalidPipelineIndex;
       }
 
       auto source = loadShader(variant, std::move(assetMgr));
@@ -367,7 +365,7 @@ public:
       if (!shader)
       {
          benchLogFmt(m_logger.get(), system::ILogger::ELL_ERROR, "createPipeline({}): shader load/compile failed", tag);
-         return idx;
+         return InvalidPipelineIndex;
       }
 
       video::IGPUComputePipeline::SCreationParams pp = {};
@@ -381,7 +379,7 @@ public:
       if (!m_device->createComputePipelines(nullptr, {&pp, 1}, &pipeline) || !pipeline)
       {
          benchLogFmt(m_logger.get(), system::ILogger::ELL_ERROR, "createPipeline({}): createComputePipelines failed", tag);
-         return idx;
+         return InvalidPipelineIndex;
       }
 
       if (m_device->getEnabledFeatures().pipelineExecutableInfo)
@@ -408,6 +406,8 @@ public:
 
       slot.layout   = std::move(layout);
       slot.pipeline = std::move(pipeline);
+      const uint32_t idx = uint32_t(m_pipelines.size());
+      m_pipelines.push_back(std::move(slot));
       return idx;
    }
 
@@ -652,6 +652,18 @@ public:
    }
 
 protected:
+   static constexpr uint32_t InvalidPipelineIndex = std::numeric_limits<uint32_t>::max();
+
+   const PipelineEntry* getPipelineEntry(uint32_t idx, std::string_view context) const
+   {
+      if (idx == InvalidPipelineIndex || idx >= m_pipelines.size() || !m_pipelines[idx].pipeline)
+      {
+         benchLogFmt(m_logger.get(), nbl::system::ILogger::ELL_ERROR, "{}: pipeline is not available", context);
+         return nullptr;
+      }
+      return &m_pipelines[idx];
+   }
+
    std::vector<PipelineEntry> m_pipelines;
 
 private:

--- a/common/include/nbl/examples/Tester/FailureManifest.h
+++ b/common/include/nbl/examples/Tester/FailureManifest.h
@@ -1,0 +1,331 @@
+#ifndef _NBL_COMMON_TESTER_FAILURE_MANIFEST_INCLUDED_
+#define _NBL_COMMON_TESTER_FAILURE_MANIFEST_INCLUDED_
+
+#include <nabla.h>
+
+#include "nlohmann/json.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <set>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace nbl::examples::testing
+{
+
+struct FailureCase
+{
+   std::string check;
+   std::string side;
+   uint64_t iteration = 0;
+   uint32_t seed = 0;
+   double maxRelative = 0.0;
+   double maxAbsolute = 0.0;
+};
+
+struct FailureGroup
+{
+   std::string phase;
+   std::string id;
+   std::string name;
+   std::string logFile;
+   std::vector<FailureCase> cases;
+   uint32_t omittedCases = 0;
+};
+
+class FailureManifest
+{
+   public:
+   explicit FailureManifest(std::string suite = {}) : m_suite(std::move(suite)) {}
+
+   void setSuite(std::string suite) { m_suite = std::move(suite); }
+
+   void addGroupFailure(std::string_view phase, std::string_view id, std::string_view name, std::string_view logFile = {})
+   {
+      auto& group = groupFor(phase, id, name);
+      if (!logFile.empty())
+         group.logFile = std::string(logFile);
+   }
+
+   void addCase(std::string_view phase, std::string_view id, std::string_view name, std::string_view check, std::string_view side,
+      uint64_t iteration, uint32_t seed, double maxRelative, double maxAbsolute)
+   {
+      auto& group = groupFor(phase, id, name);
+      if (group.cases.size() >= MaxCasesPerGroup)
+      {
+         ++group.omittedCases;
+         return;
+      }
+
+      group.cases.push_back(FailureCase{
+         .check = std::string(check),
+         .side = std::string(side),
+         .iteration = iteration,
+         .seed = seed,
+         .maxRelative = maxRelative,
+         .maxAbsolute = maxAbsolute,
+      });
+   }
+
+   const std::vector<FailureGroup>& failures() const { return m_failures; }
+
+   nlohmann::json toJson() const
+   {
+      nlohmann::json doc;
+      doc["version"] = 1;
+      doc["suite"] = m_suite;
+      auto& failures = doc["failures"] = nlohmann::json::array();
+
+      for (const auto& group : m_failures)
+      {
+         nlohmann::json g;
+         g["phase"] = group.phase;
+         g["id"] = group.id;
+         g["name"] = group.name;
+         if (!group.logFile.empty())
+            g["log_file"] = group.logFile;
+
+         auto& cases = g["cases"] = nlohmann::json::array();
+         for (const auto& c : group.cases)
+         {
+            nlohmann::json row;
+            row["check"] = c.check;
+            row["side"] = c.side;
+            row["iteration"] = c.iteration;
+            row["seed"] = c.seed;
+            row["max_relative"] = c.maxRelative;
+            row["max_absolute"] = c.maxAbsolute;
+            cases.push_back(std::move(row));
+         }
+
+         if (group.omittedCases > 0)
+            g["omitted_cases"] = group.omittedCases;
+
+         failures.push_back(std::move(g));
+      }
+
+      return doc;
+   }
+
+   private:
+   static constexpr size_t MaxCasesPerGroup = 64;
+
+   FailureGroup& groupFor(std::string_view phase, std::string_view id, std::string_view name)
+   {
+      const std::string idString(id);
+      auto it = std::find_if(m_failures.begin(), m_failures.end(), [&](const FailureGroup& g) { return g.id == idString; });
+      if (it != m_failures.end())
+      {
+         if (it->name.empty())
+            it->name = std::string(name);
+         if (it->phase.empty())
+            it->phase = std::string(phase);
+         return *it;
+      }
+
+      m_failures.push_back(FailureGroup{
+         .phase = std::string(phase),
+         .id = idString,
+         .name = std::string(name),
+      });
+      return m_failures.back();
+   }
+
+   std::string m_suite;
+   std::vector<FailureGroup> m_failures;
+};
+
+class TestFilter
+{
+   public:
+   bool enabled() const { return m_enabled; }
+
+   void enable() { m_enabled = true; }
+
+   bool shouldRun(std::string_view id) const
+   {
+      return !m_enabled || m_ids.contains(std::string(id));
+   }
+
+   void add(std::string_view id)
+   {
+      m_enabled = true;
+      const auto first = id.find_first_not_of(" \t\r\n");
+      if (first == std::string_view::npos)
+         return;
+      const auto last = id.find_last_not_of(" \t\r\n");
+      m_ids.insert(std::string(id.substr(first, last - first + 1)));
+   }
+
+   void addSeed(std::string_view id, uint32_t seed)
+   {
+      add(id);
+      m_seeds[std::string(id)] = seed;
+   }
+
+   void addList(std::string_view ids)
+   {
+      m_enabled = true;
+      while (!ids.empty())
+      {
+         const auto comma = ids.find(',');
+         add(ids.substr(0, comma));
+         if (comma == std::string_view::npos)
+            return;
+         ids.remove_prefix(comma + 1);
+      }
+   }
+
+   std::optional<uint32_t> seedFor(std::string_view id) const
+   {
+      auto it = m_seeds.find(std::string(id));
+      if (it == m_seeds.end())
+         return {};
+      return it->second;
+   }
+
+   private:
+   bool m_enabled = false;
+   std::set<std::string> m_ids;
+   std::map<std::string, uint32_t> m_seeds;
+};
+
+struct RunControl
+{
+   bool valid = true;
+   bool skipBenchmarks = false;
+   std::string failedOutPath;
+   TestFilter filter;
+};
+
+inline bool addFailedIdsFromFile(TestFilter& filter, const std::string& path, nbl::system::ILogger* logger)
+{
+   filter.enable();
+   std::ifstream in(path);
+   if (!in.is_open())
+   {
+      if (logger)
+         logger->log("Failed to open failed-test manifest '%s'", nbl::system::ILogger::ELL_ERROR, path.c_str());
+      return false;
+   }
+
+   nlohmann::json doc;
+   try
+   {
+      in >> doc;
+   }
+   catch (const std::exception& e)
+   {
+      if (logger)
+         logger->log("Failed to parse failed-test manifest '%s': %s", nbl::system::ILogger::ELL_ERROR, path.c_str(), e.what());
+      return false;
+   }
+
+   const auto failuresIt = doc.find("failures");
+   if (failuresIt == doc.end() || !failuresIt->is_array())
+   {
+      if (logger)
+         logger->log("Failed-test manifest '%s' does not contain a failures array", nbl::system::ILogger::ELL_ERROR, path.c_str());
+      return false;
+   }
+
+   for (const auto& failure : *failuresIt)
+   {
+      if (!failure.is_object())
+         continue;
+      const auto idIt = failure.find("id");
+      if (idIt != failure.end() && idIt->is_string())
+      {
+         const std::string id = idIt->get<std::string>();
+         const auto casesIt = failure.find("cases");
+         if (casesIt != failure.end() && casesIt->is_array())
+         {
+            const auto seedIt = std::find_if(casesIt->begin(), casesIt->end(), [](const nlohmann::json& row) {
+               if (!row.is_object())
+                  return false;
+               const auto it = row.find("seed");
+               return it != row.end() && it->is_number_integer();
+            });
+            if (seedIt != casesIt->end())
+            {
+               filter.addSeed(id, (*seedIt)["seed"].get<uint32_t>());
+               continue;
+            }
+         }
+         filter.add(id);
+      }
+   }
+
+   return true;
+}
+
+inline RunControl parseRunControl(std::span<const std::string> argv, nbl::system::ILogger* logger)
+{
+   RunControl out;
+
+   for (size_t i = 1; i < argv.size(); ++i)
+   {
+      const std::string& arg = argv[i];
+      if (arg == "--skip-benchmarks")
+         out.skipBenchmarks = true;
+      else if (arg == "--failed-out" && i + 1 < argv.size())
+         out.failedOutPath = argv[++i];
+      else if (arg.starts_with("--failed-out="))
+         out.failedOutPath = arg.substr(std::string("--failed-out=").size());
+      else if (arg == "--test" && i + 1 < argv.size())
+         out.filter.addList(argv[++i]);
+      else if (arg.starts_with("--test="))
+         out.filter.addList(std::string_view(arg).substr(std::string_view("--test=").size()));
+      else if (arg == "--rerun-failed" && i + 1 < argv.size())
+      {
+         if (!addFailedIdsFromFile(out.filter, argv[++i], logger))
+            out.valid = false;
+      }
+      else if (arg.starts_with("--rerun-failed="))
+      {
+         if (!addFailedIdsFromFile(out.filter, arg.substr(std::string("--rerun-failed=").size()), logger))
+            out.valid = false;
+      }
+   }
+
+   if (out.filter.enabled())
+      out.skipBenchmarks = true;
+
+   return out;
+}
+
+inline bool writeFailureManifestFile(const FailureManifest& manifest, const std::string& path, nbl::system::ILogger* logger)
+{
+   std::ofstream out(path, std::ios::out | std::ios::trunc);
+   if (!out.is_open())
+   {
+      if (logger)
+         logger->log("Failed to open failed-test manifest '%s' for writing", nbl::system::ILogger::ELL_ERROR, path.c_str());
+      return false;
+   }
+
+   out << manifest.toJson().dump(3) << '\n';
+   if (!out.good())
+   {
+      if (logger)
+         logger->log("Failed to write failed-test manifest '%s'", nbl::system::ILogger::ELL_ERROR, path.c_str());
+      return false;
+   }
+
+   if (logger)
+      logger->log("Wrote failed-test manifest '%s' with %llu failed groups", nbl::system::ILogger::ELL_INFO,
+         path.c_str(), static_cast<unsigned long long>(manifest.failures().size()));
+   return true;
+}
+
+} // namespace nbl::examples::testing
+
+#endif

--- a/common/include/nbl/examples/Tester/ITester.h
+++ b/common/include/nbl/examples/Tester/ITester.h
@@ -3,6 +3,7 @@
 
 #include <nabla.h>
 #include <nbl/system/to_string.h>
+#include <nbl/examples/Tester/FailureManifest.h>
 #include <ranges>
 #include <nbl/builtin/hlsl/testing/relative_approx_compare.hlsl>
 #include <nbl/builtin/hlsl/testing/approx_compare.hlsl>
@@ -171,6 +172,7 @@ class ITester
 
    bool performTestsAndVerifyResults(const std::string& logFileName)
    {
+      m_failureLogFile = logFileName;
       m_logFile.open(logFileName, std::ios::out | std::ios::trunc);
       if (!m_logFile.is_open())
          m_logger->log("Failed to open log file!", system::ILogger::ELL_ERROR);
@@ -197,12 +199,28 @@ class ITester
       core::vector<TestResults> gpuTestResults = performGpuTests(inputTestValues);
 
       bool pass = verifyAllTestResults(cpuTestResults, gpuTestResults, exceptedTestResults);
+      if (!pass && m_failureManifest)
+         m_failureManifest->addGroupFailure(m_failurePhase, m_failureId, m_failureName, m_failureLogFile);
 
       m_logger->log("TESTS DONE.", system::ILogger::ELL_PERFORMANCE);
       reloadSeed();
 
       m_logFile.close();
       return pass;
+   }
+
+   void setFailureRecordContext(nbl::examples::testing::FailureManifest* manifest, std::string phase, std::string id, std::string name)
+   {
+      m_failureManifest = manifest;
+      m_failurePhase = std::move(phase);
+      m_failureId = std::move(id);
+      m_failureName = std::move(name);
+   }
+
+   void setSeed(uint32_t seed)
+   {
+      m_seed = seed;
+      m_mersenneTwister = std::mt19937(m_seed);
    }
 
    virtual ~ITester()
@@ -339,6 +357,13 @@ class ITester
          ss << " DIFFERENCE: " << system::to_string(hlsl::abs(expectedVal - testVal));
       ss << " MAX RELATIVE: " << system::to_string(maxRelativeDifference) << " MAX ABSOLUTE " << system::to_string(maxAbsoluteDifference) << '\n';
 
+      if (m_failureManifest)
+      {
+         const char* side = testType == TestType::CPU ? "CPU" : "GPU";
+         m_failureManifest->addCase(m_failurePhase, m_failureId, m_failureName, memberName, side,
+            testIteration, seed, maxRelativeDifference, maxAbsoluteDifference);
+      }
+
       m_logger->log("%s", system::ILogger::ELL_ERROR, ss.str().c_str());
       m_logFile << ss.str() << '\n';
    }
@@ -439,6 +464,11 @@ class ITester
    uint32_t m_seed;
    std::ofstream m_logFile;
    core::unordered_map<std::string, hlsl::testing::SMaxError> m_maxErrors;
+   nbl::examples::testing::FailureManifest* m_failureManifest = nullptr;
+   std::string m_failurePhase;
+   std::string m_failureId;
+   std::string m_failureName;
+   std::string m_failureLogFile;
 };
 
 #endif


### PR DESCRIPTION
## Summary

- Fix GPU benchmark submission sync by splitting long benchmark rows into bounded GPU batches.
- Treat failed pipeline creation as an invalid benchmark row instead of using a null pipeline entry later.
- Add reusable failed-test manifests and wire them into EX37. A full run can write failed groups to JSON and a follow-up run can execute only those groups with captured seeds.
- Make benchmark JSON baseline loading tolerate missing or malformed files.

## Root cause

The benchmark helper accumulated all per-row dispatches into one command buffer and submitted it as a single large GPU job. On RTX 4070 this could trip device lost for the new benchmark rows even though the same workload can finish when split into smaller submissions.

The fix follows the same direction as the ImGui backend batching. Each submitted GPU batch is bounded and waited on before the next batch is submitted.

Benchmark rows also assumed every pipeline entry was valid. Failed creation could leak into later row setup instead of becoming an invalid benchmark row.

## Rerun failed

The manifest helper is shared under the examples tester code. This PR wires it into EX37 so a full run can write a small manifest with the failed groups and seeds.

```text
--failed-out failed_ex37_rwdi.json
```

For the current repro, save the JSON below as `failed_ex37_rwdi.json` in the EX37 executable working directory. Then run:

```text
--rerun-failed failed_ex37_rwdi.json --failed-out failed_ex37_rwdi_rerun.json
```

The current RelWithDebInfo repro manifest is:

```json
{
   "failures": [
      {
         "cases": [
            {
               "check": "Linear::jacobianProduct",
               "iteration": 176770,
               "max_absolute": 0.06,
               "max_relative": 0.06,
               "seed": 3677032954,
               "side": "CPU"
            },
            {
               "check": "Linear::jacobianProduct",
               "iteration": 176770,
               "max_absolute": 0.06,
               "max_relative": 0.06,
               "seed": 3677032954,
               "side": "GPU"
            }
         ],
         "id": "sampler/Linear",
         "log_file": "LinearTestLog.txt",
         "name": "Linear sampler",
         "phase": "sampler"
      },
      {
         "cases": [
            {
               "check": "ProjectedSphericalTriangle::jacobianProduct",
               "iteration": 247232,
               "max_absolute": 2.0,
               "max_relative": 2.0,
               "seed": 4103190276,
               "side": "CPU"
            }
         ],
         "id": "sampler/ProjectedSphericalTriangle",
         "log_file": "ProjectedSphericalTriangleTestLog.txt",
         "name": "ProjectedSphericalTriangle sampler",
         "phase": "sampler"
      }
   ],
   "suite": "37_HLSLSamplingTests",
   "version": 1
}
```

## Env

- AMD Ryzen 5 5600G
- NVIDIA GeForce RTX 4070
- NVIDIA driver 32.0.15.9636
- VulkanSDK 1.4.341.1
- VS2022 Dynamic
- Debug and RelWithDebInfo

## Current EX37 result

Debug passes. RelWithDebInfo no longer hits device lost. It reaches the original sampler checks and reproduces two unrelated jacobian failures.

```text
CPU TEST ERROR
nbl::hlsl::Linear::jacobianProduct produced incorrect output
TEST ITERATION INDEX 176770 SEED 3677032954
EXPECTED VALUE 1 TEST VALUE 0.9399732 DIFFERENCE 0.060026824 MAX RELATIVE 0.06 MAX ABSOLUTE 0.06

GPU TEST ERROR
nbl::hlsl::Linear::jacobianProduct produced incorrect output
TEST ITERATION INDEX 176770 SEED 3677032954
EXPECTED VALUE 1 TEST VALUE 0.9399732 DIFFERENCE 0.060026824 MAX RELATIVE 0.06 MAX ABSOLUTE 0.06

CPU TEST ERROR
nbl::hlsl::ProjectedSphericalTriangle::jacobianProduct produced incorrect output
TEST ITERATION INDEX 247232 SEED 4103190276
EXPECTED VALUE 1 TEST VALUE 3.0213876 DIFFERENCE 2.0213876 MAX RELATIVE 2 MAX ABSOLUTE 2
```
